### PR TITLE
add CORS setting to support react native template

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,6 +11,7 @@ app = FastAPI()
 origins = [
     "http://localhost:8000",
     "http://localhost:3000",
+    "http://localhost:19006"
 ]
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
- Add `http://localhost:19006` to CORS setting to support [my React Native template](https://github.com/masaiborg/expo-react-native-base)